### PR TITLE
docker build 로컬에서

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,11 @@ RUN npm run build
 FROM node:18
 
 WORKDIR /app
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/package*.json ./
+# 로컬에서 빌드된 dist 복사
+COPY ./dist ./dist
+COPY ./package*.json ./
+
+# 운영환경 의존성만 설치
 
 RUN npm install --only=production
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,4 @@ services:
     ports:
       - '3000:3000'
     restart: always
+    env_file: .env


### PR DESCRIPTION
ec2 용량문제때문에, 로컬에서 빌드하고 dist/만 배포하는 방식!!!


로컬에서 코드를 수정하고

npm run build로 dist/를 새로 만들고

그걸 EC2에 scp로 업로드한 뒤

docker-compose up -d --build로 다시 띄우는 구조